### PR TITLE
UserService and EmailService

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.springframework.security:spring-security-crypto")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/ActivationDTO.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/ActivationDTO.kt
@@ -5,4 +5,4 @@ import java.util.UUID
 
 data class ActivationDTO(val provisionalId: UUID, val email: String, val activationCode: String?)
 
-fun Activation.DTO() = ActivationDTO(id, userActivation.email, activationCode)
+fun Activation.DTO() = ActivationDTO(id!!, userActivation.email, activationCode)

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/UserDTO.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/UserDTO.kt
@@ -2,6 +2,5 @@ package it.polito.wa2.group03userregistration.dtos
 
 import it.polito.wa2.group03userregistration.entities.User
 
-data class UserDTO(val username: String, val email: String)
-
-fun User.toUserDTO() = UserDTO(username, email)
+data class UserDTO(val userId: Long?, val username: String, val email: String, val password: String?)
+fun User.toUserDTO() = UserDTO(id, username, email, password)

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/entities/Activation.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/entities/Activation.kt
@@ -1,6 +1,6 @@
 package it.polito.wa2.group03userregistration.entities
 
-import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
 import java.util.Date
 import java.util.UUID
 import javax.persistence.*
@@ -11,9 +11,9 @@ class Activation(@OneToOne var userActivation: User, var activationCode: String)
     @GeneratedValue(strategy = GenerationType.AUTO)
     var id: UUID? = null
 
-    @CreationTimestamp
+
     @Temporal(TemporalType.TIMESTAMP)
-    lateinit var expirationDate: Date
+    var expirationDate: Date? = java.sql.Timestamp.valueOf(LocalDateTime.now().plusHours(6))
 
     var attempt: Int = 5
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/entities/Activation.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/entities/Activation.kt
@@ -1,20 +1,19 @@
 package it.polito.wa2.group03userregistration.entities
 
+import org.hibernate.annotations.CreationTimestamp
+import java.util.Date
 import java.util.UUID
 import javax.persistence.*
 
 @Entity
-class Activation {
-
+class Activation(@OneToOne var userActivation: User, var activationCode: String) {
     @Id
-    @GeneratedValue
-    lateinit var id: UUID
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    var id: UUID? = null
 
-    @OneToOne
-    lateinit var userActivation: User
-
-    var activationCode: String? = null
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    lateinit var expirationDate: Date
 
     var attempt: Int = 5
-
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/entities/User.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/entities/User.kt
@@ -9,17 +9,13 @@ import javax.persistence.Table
 
 @Entity
 @Table(name="ApplicationUser")
-class User {
+class User(var username: String,var password: String?, var email: String) {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     var id: Long? = null;
 
-    var username: String = ""
-    var password: String = ""
     var salt: String = ""
-    var email: String = ""
-
     @OneToOne(mappedBy="userActivation")
     var activation: Activation? = null
 

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/other/ScheduledPruneJob.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/other/ScheduledPruneJob.kt
@@ -1,0 +1,28 @@
+package it.polito.wa2.group03userregistration.other
+
+import it.polito.wa2.group03userregistration.repositories.ActivationRepository
+import it.polito.wa2.group03userregistration.repositories.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import java.time.LocalDateTime
+
+@EnableScheduling
+@Configuration
+class ScheduledPruneJob {
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var activationRepository: ActivationRepository
+
+    @Scheduled(initialDelayString = "PT01M", fixedDelayString = "PT01M")
+    fun checkExpiredRegistrationToken() {
+        val expiredRecords = activationRepository.findAll().filter { it.expirationDate!!.before(java.sql.Timestamp.valueOf(
+            LocalDateTime.now())) }
+        expiredRecords.forEach {
+            activationRepository.deleteById(it.id!!)
+            userRepository.deleteById(it.userActivation.id!!) }
+    }
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
@@ -1,0 +1,30 @@
+package it.polito.wa2.group03userregistration.services
+
+import it.polito.wa2.group03userregistration.dtos.ActivationDTO
+import it.polito.wa2.group03userregistration.dtos.DTO
+import it.polito.wa2.group03userregistration.entities.Activation
+import it.polito.wa2.group03userregistration.entities.User
+import it.polito.wa2.group03userregistration.repositories.ActivationRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class EmailService {
+
+    private val ACTIVATIONCODE_LENGTH = 10
+    private val charPool: List<Char> = ('a'..'z') + ('A'..'Z')+('0'..'9')
+    @Autowired
+    lateinit var activationRepository: ActivationRepository
+    fun insertActivation(user: User): ActivationDTO {
+        val savedEntity = activationRepository.save(Activation(user, generateActivationCode()))
+        return savedEntity.DTO()
+    }
+
+    fun generateActivationCode(): String {
+        return (1..ACTIVATIONCODE_LENGTH)
+            .map { kotlin.random.Random.nextInt(0, charPool.size) }
+            .map { charPool[it] }
+            .joinToString("")
+    }
+
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
@@ -6,18 +6,36 @@ import it.polito.wa2.group03userregistration.entities.Activation
 import it.polito.wa2.group03userregistration.entities.User
 import it.polito.wa2.group03userregistration.repositories.ActivationRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mail.MailException
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
+import java.text.SimpleDateFormat
+import java.util.*
 
 @Service
-class EmailService {
+class EmailService{
 
     private val ACTIVATIONCODE_LENGTH = 10
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z')+('0'..'9')
     @Autowired
     lateinit var activationRepository: ActivationRepository
-    fun insertActivation(user: User): ActivationDTO {
-        val savedEntity = activationRepository.save(Activation(user, generateActivationCode()))
-        return savedEntity.DTO()
+
+    @Autowired
+    lateinit var mailSender: JavaMailSender;
+
+    fun insertActivation(user: User): ActivationDTO? {
+        var savedEntity: Activation? = null
+
+        try {
+            savedEntity = activationRepository.save(Activation(user, generateActivationCode()))
+            sendMail(savedEntity.userActivation.email, savedEntity.userActivation.username,savedEntity.activationCode, savedEntity.expirationDate!!)
+        } catch (e: MailException) {
+            e.printStackTrace()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return savedEntity?.DTO()
     }
 
     fun generateActivationCode(): String {
@@ -25,6 +43,16 @@ class EmailService {
             .map { kotlin.random.Random.nextInt(0, charPool.size) }
             .map { charPool[it] }
             .joinToString("")
+    }
+
+    fun sendMail(toEmail: String, username: String, activationCode: String, expirationDate: Date){
+        val message = SimpleMailMessage()
+        message.setFrom("group03NML@gmail.com")
+        message.setTo(toEmail)
+        message.setText("Hello $username! This is your activation code $activationCode. Please use it before ${SimpleDateFormat("yyyy-mm-dd hh:mm:ss").format(expirationDate)}.\nHave a nice day!")
+        message.setSubject("Activation code")
+
+        mailSender.send(message)
     }
 
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
@@ -1,0 +1,39 @@
+package it.polito.wa2.group03userregistration.services
+
+import it.polito.wa2.group03userregistration.dtos.UserDTO
+import it.polito.wa2.group03userregistration.entities.User
+import it.polito.wa2.group03userregistration.repositories.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.crypto.bcrypt.BCrypt
+import org.springframework.stereotype.Service
+
+@Service
+class UserService {
+    val passwordRegex = Regex("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$")
+    val emailRegex = Regex("(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])")
+    @Autowired
+    lateinit var emailService: EmailService;
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    fun registerUser(userToRegister: UserDTO): ValidationUser {
+        var user = User(userToRegister.username, userToRegister.password, userToRegister.email)
+        if(!isValidUser(user)) return ValidationUser.USER_NOT_VALID
+        user.salt = BCrypt.gensalt(10)
+        user.password = BCrypt.hashpw(user.password, user.salt)
+        val savedUser = userRepository.save(user)
+        val activationDTO = emailService.insertActivation(savedUser);
+        println(activationDTO)
+        return ValidationUser.VALID
+    }
+
+    fun isValidUser(user: User): Boolean {
+        // TODO("Check is username and email are System Unique")
+        return  user.username.isNotBlank() &&
+                user.email.isNotBlank() &&
+                user.password!!.isNotBlank() &&
+                user.password!!.matches(passwordRegex) &&
+                user.email.matches(emailRegex)
+    }
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/ValidationUser.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/ValidationUser.kt
@@ -1,0 +1,6 @@
+package it.polito.wa2.group03userregistration.services
+
+enum class ValidationUser {
+    VALID,
+    USER_NOT_VALID
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,6 @@ spring.jpa.hibernate.ddl-auto=create
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=group03nml@gmail.com
-spring.mail.password=zktutktizttghoea
+spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 spring.jpa.hibernate.ddl-auto=create
-spring.jpa.hibernate.show-sql=true
-spring.datasource.url=
-spring.datasource.username=postgres
-spring.datasource.password=
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgresSQLDialect
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=group03nml@gmail.com
+spring.mail.password=zktutktizttghoea
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
@@ -1,0 +1,23 @@
+package it.polito.wa2.group03userregistration.service
+
+import it.polito.wa2.group03userregistration.dtos.UserDTO
+import it.polito.wa2.group03userregistration.services.UserService
+import it.polito.wa2.group03userregistration.services.ValidationUser
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    lateinit var userService: UserService
+
+    @Test
+    fun insertValidUser() {
+        val user = UserDTO(null,  "alex142", "alessandrobacci142@gmail.com", "Pass!w0rd")
+        Assertions.assertEquals(ValidationUser.VALID, userService.registerUser(user))
+    }
+
+}


### PR DESCRIPTION
In this PR there is a first implementation of the `UserService` and `EmailService`. The first approach with JPA and Database was literally _bang_  :exploding_head: 

#### What is missing?
- [x] Check if `username` and `email` are unique system-wide.
- [x] Increase the possible test to check: _incorrect UserDTO_, _correct/incorrect ValidationDTO_ etc.
- [x] Send mail 6e0067f
- [x] Scheduled job to periodically prune the expired registration data (added with afe4f31 commit): the first execution is delayed of 1 minute, then the job is periodically executed every minute. More details [here](https://reflectoring.io/spring-scheduler/)

Notes: 
- the registration token duration is `6 hours` and is set when the `Validation` entity is created.

Please add your suggestions to this first implementation attempt . . .


