### PR TITLE
RateLimitInterceptor + integration tests for RateLimitInterceptor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.security:spring-security-crypto")
+    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core:7.3.0")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/AppConfig.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/AppConfig.kt
@@ -1,0 +1,18 @@
+package it.polito.wa2.group03userregistration
+
+import it.polito.wa2.group03userregistration.interceptors.RateLimiterInterceptor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class AppConfig : WebMvcConfigurer {
+
+    @Autowired
+    lateinit var interceptor: RateLimiterInterceptor
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(interceptor).addPathPatterns("/users/**")
+    }
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/controllers/WebController.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/controllers/WebController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
-// Data returned by POST /user/register
+// Data returned by POST /users/register
 interface RegisterResponse
 data class RegisterResponseOK(
     val provisional_id: UUID,
@@ -27,7 +27,7 @@ data class RegisterResponseError(
     val errorMessage: String?
 ) : RegisterResponse
 
-// Data returned by POST /user/validate
+// Data returned by POST /users/validate
 interface ValidateResponse
 data class ValidateResponseOK(
     val userId: Long,
@@ -45,7 +45,7 @@ class WebController {
     @Autowired
     lateinit var userService: UserService
 
-    @PostMapping("/user/register")
+    @PostMapping("/users/register")
     fun registerUser(@RequestBody payload: UserDTO): ResponseEntity<RegisterResponse> {
         val registerDTO = userService.registerUser(payload)
         val resBody: RegisterResponse
@@ -59,7 +59,7 @@ class WebController {
         }
     }
 
-    @PostMapping("/user/validate")
+    @PostMapping("/users/validate")
     fun validateUser(@RequestBody payload: ActivationDTO): ResponseEntity<ValidateResponse> {
         val validateDTO = userService.validateUser(payload)
         val resBody: ValidateResponse

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/UserDTO.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/dtos/UserDTO.kt
@@ -4,4 +4,4 @@ import it.polito.wa2.group03userregistration.entities.User
 
 data class UserDTO(val userId: Long?, val username: String, val email: String, val password: String?)
 
-fun User.toUserDTO() = UserDTO(id, username, email, password)
+fun User.toDTO() = UserDTO(id, username, email, password)

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/interceptors/RateLimiterInterceptor.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/interceptors/RateLimiterInterceptor.kt
@@ -1,0 +1,33 @@
+package it.polito.wa2.group03userregistration.interceptors
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Refill
+import io.github.bucket4j.local.LocalBucket
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Service
+class RateLimiterInterceptor : HandlerInterceptor {
+
+    private val bucket: LocalBucket = Bucket
+        .builder()
+        .addLimit(
+            Bandwidth
+                .classic(10, Refill.intervally(10, java.time.Duration.ofMinutes(1)))
+        )
+        .build()
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        return if (bucket.tryConsume(1)) {
+            true
+        } else {
+            response.sendError(HttpStatus.TOO_MANY_REQUESTS.value())
+            false
+        }
+
+    }
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
@@ -56,9 +56,9 @@ class EmailService {
         message.setFrom("group03NML@gmail.com")
         message.setTo(toEmail)
         message.setText(
-            "Hello $username! This is your activation code $activationCode. Please use it before ${
+            "Hello $username! This is your activation code:\n\n$activationCode \n\nPlease use it before ${
                 SimpleDateFormat(
-                    "yyyy-mm-dd hh:mm:ss"
+                    "yyyy-MM-dd hh:mm:ss"
                 ).format(expirationDate)
             }.\nHave a nice day!"
         )

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
@@ -46,15 +46,15 @@ class UserService {
     }
 
     fun isValidUser(user: User): UserValidationStatus {
-        user.username.isNotBlank() || return UserValidationStatus.NO_USERNAME
-        user.email.isNotBlank() || return UserValidationStatus.NO_EMAIL
-        user.password!!.isNotBlank() || return UserValidationStatus.NO_PASSWORD
-        user.password!!.matches(passwordRegex) || return UserValidationStatus.WEAK_PASSWORD
-        user.email.matches(emailRegex) || return UserValidationStatus.INVALID_EMAIL
-
-        // TODO("Check is username and email are System Unique")
-
-        return UserValidationStatus.VALID
+        // TODO("Check if username and email are System Unique")
+        return when {
+            user.username.isBlank() -> UserValidationStatus.NO_USERNAME
+            user.email.isBlank() -> UserValidationStatus.NO_EMAIL
+            user.password!!.isBlank() -> UserValidationStatus.NO_PASSWORD
+            !user.password!!.matches(passwordRegex) -> UserValidationStatus.WEAK_PASSWORD
+            !user.email.matches(emailRegex) -> UserValidationStatus.INVALID_EMAIL
+            else -> UserValidationStatus.VALID
+        }
     }
 
     fun validateUser(activation: ActivationDTO): ValidateDTO {
@@ -84,6 +84,6 @@ class UserService {
         }
 
         activationRepository.deleteById(activation.provisionalId)
-        return ValidateDTO(ActivationStatus.SUCCESSFUL, savedActivation.userActivation.toUserDTO())
+        return ValidateDTO(ActivationStatus.SUCCESSFUL, savedActivation.userActivation.toDTO())
     }
 }

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/integration/RateLimiterTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/integration/RateLimiterTest.kt
@@ -1,0 +1,87 @@
+package it.polito.wa2.group03userregistration.integration
+
+import it.polito.wa2.group03userregistration.dtos.ActivationDTO
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.postForEntity
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpStatus
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.annotation.DirtiesContext.ClassMode
+import java.util.*
+
+// This attribute recreates the WebServer before each test, this is a simple-yet-ugly
+// workaround to re-initialize the already checked ticket list before each test
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RateLimiterTest {
+
+    @LocalServerPort
+    var port: Int = 0
+
+    @Autowired
+    lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun `Normal request flow`() {
+        // Arrange
+        val baseUrl = "http://localhost:$port"
+        val request = HttpEntity(ActivationDTO(UUID.randomUUID(), "test-email", "123"))
+
+        // Act
+        val response = restTemplate.postForEntity<String>(
+            "$baseUrl/users/validate",
+            request
+        )
+
+        // Assert
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+    }
+
+    @Test
+    fun `Too many requests after 10 requests`() {
+        // Arrange
+        val baseUrl = "http://localhost:$port"
+        val request = HttpEntity(ActivationDTO(UUID.randomUUID(), "test-email", "123"))
+        for (i in (1..10)) {
+            restTemplate.postForEntity<String>(
+                "$baseUrl/users/validate",
+                request
+            )
+        }
+
+        // Act
+        val response = restTemplate.postForEntity<String>(
+            "$baseUrl/users/validate",
+            request
+        )
+
+        // Assert
+        Assertions.assertEquals(HttpStatus.TOO_MANY_REQUESTS, response.statusCode)
+    }
+
+    @Test
+    fun `10 valid requests allowed`() {
+        // Arrange
+        val baseUrl = "http://localhost:$port"
+        val request = HttpEntity(ActivationDTO(UUID.randomUUID(), "test-email", "123"))
+        val responses = mutableListOf<HttpStatus>()
+
+        // Act
+        for (i in (1..10)) {
+            responses.add(
+                restTemplate.postForEntity<String>(
+                    "$baseUrl/users/validate",
+                    request
+                ).statusCode
+            )
+        }
+
+        // Assert
+        Assertions.assertEquals(10, responses.count { it == HttpStatus.NOT_FOUND })
+    }
+}


### PR DESCRIPTION
This PR introduces a `RateLimitInterceptor` class with a default 10 token bucket that gets refilled each minute.

The chosen algorithm (called `intervally`) waits one minute before refilling the token bucket; otherwise a `greedy` algorithm can be chosen whereas new tokens are placed in the bucket at regular intervals (e.g. 10 tokens each minute means that a new token will be added each 6 seconds)

Fix #8 fix #7 