### PR TITLE
test email service + user service

### DIFF
--- a/src/main/kotlin/it/polito/wa2/group03userregistration/repositories/UserRepository.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/repositories/UserRepository.kt
@@ -14,4 +14,5 @@ interface UserRepository : CrudRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.username = ?1")
     fun findByUsername(username: String): User?
+
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/repositories/UserRepository.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/repositories/UserRepository.kt
@@ -1,9 +1,17 @@
 package it.polito.wa2.group03userregistration.repositories
 
 import it.polito.wa2.group03userregistration.entities.User
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 
 @Repository
-interface UserRepository : CrudRepository<User, Long> {}
+interface UserRepository : CrudRepository<User, Long> {
+
+    @Query("SELECT u FROM User u WHERE u.email = ?1")
+    fun findByEmail(email: String): User?
+
+    @Query("SELECT u FROM User u WHERE u.username = ?1")
+    fun findByUsername(username: String): User?
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
@@ -53,7 +53,12 @@ class EmailService {
             .joinToString("")
     }
 
-    fun generateMail(toEmail: String, username: String, activationCode: String, expirationDate: Date): SimpleMailMessage {
+    fun generateMail(
+        toEmail: String,
+        username: String,
+        activationCode: String,
+        expirationDate: Date
+    ): SimpleMailMessage {
         val message = SimpleMailMessage()
         message.setFrom("group03NML@gmail.com")
         message.setTo(toEmail)

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailService.kt
@@ -31,10 +31,12 @@ class EmailService {
         try {
             savedEntity = activationRepository.save(Activation(user, generateActivationCode()))
             sendMail(
-                savedEntity.userActivation.email,
-                savedEntity.userActivation.username,
-                savedEntity.activationCode,
-                savedEntity.expirationDate!!
+                generateMail(
+                    savedEntity.userActivation.email,
+                    savedEntity.userActivation.username,
+                    savedEntity.activationCode,
+                    savedEntity.expirationDate!!
+                )
             )
         } catch (e: MailException) {
             e.printStackTrace()
@@ -51,7 +53,7 @@ class EmailService {
             .joinToString("")
     }
 
-    fun sendMail(toEmail: String, username: String, activationCode: String, expirationDate: Date) {
+    fun generateMail(toEmail: String, username: String, activationCode: String, expirationDate: Date): SimpleMailMessage {
         val message = SimpleMailMessage()
         message.setFrom("group03NML@gmail.com")
         message.setTo(toEmail)
@@ -64,6 +66,10 @@ class EmailService {
         )
         message.setSubject("Activation code")
 
+        return message
+    }
+
+    fun sendMail(message: SimpleMailMessage) {
         mailSender.send(message)
     }
 

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
@@ -1,10 +1,12 @@
 package it.polito.wa2.group03userregistration.services
 
 import org.springframework.mail.SimpleMailMessage
+import org.springframework.stereotype.Service
 
+@Service
 class EmailServiceStub : EmailService() {
 
-    private lateinit var sentMails: MutableList<SimpleMailMessage>
+    private var sentMails: MutableList<SimpleMailMessage> = mutableListOf()
 
     override fun sendMail(message: SimpleMailMessage) {
         sentMails.add(message)
@@ -12,6 +14,10 @@ class EmailServiceStub : EmailService() {
 
     fun getSentMails(): MutableList<SimpleMailMessage> {
         return sentMails
+    }
+
+    fun getSentMailsSize(): Int {
+        return sentMails.size
     }
 
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
@@ -10,4 +10,8 @@ class EmailServiceStub : EmailService() {
         sentMails.add(message)
     }
 
+    fun getSentMails(): MutableList<SimpleMailMessage> {
+        return sentMails
+    }
+
 }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/EmailServiceStub.kt
@@ -1,0 +1,13 @@
+package it.polito.wa2.group03userregistration.services
+
+import org.springframework.mail.SimpleMailMessage
+
+class EmailServiceStub : EmailService() {
+
+    private lateinit var sentMails: MutableList<SimpleMailMessage>
+
+    override fun sendMail(message: SimpleMailMessage) {
+        sentMails.add(message)
+    }
+
+}

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
@@ -46,13 +46,14 @@ class UserService {
     }
 
     fun isValidUser(user: User): UserValidationStatus {
-        // TODO("Check if username and email are System Unique")
         return when {
             user.username.isBlank() -> UserValidationStatus.NO_USERNAME
             user.email.isBlank() -> UserValidationStatus.NO_EMAIL
             user.password!!.isBlank() -> UserValidationStatus.NO_PASSWORD
             !user.password!!.matches(passwordRegex) -> UserValidationStatus.WEAK_PASSWORD
             !user.email.matches(emailRegex) -> UserValidationStatus.INVALID_EMAIL
+            userRepository.findByEmail(user.email) != null -> UserValidationStatus.EMAIL_ALREADY_EXISTS
+            userRepository.findByUsername(user.username) != null -> UserValidationStatus.USERNAME_ALREADY_EXISTS
             else -> UserValidationStatus.VALID
         }
     }

--- a/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
+++ b/src/main/kotlin/it/polito/wa2/group03userregistration/services/UserService.kt
@@ -86,4 +86,5 @@ class UserService {
         activationRepository.deleteById(activation.provisionalId)
         return ValidateDTO(ActivationStatus.SUCCESSFUL, savedActivation.userActivation.toDTO())
     }
+
 }

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
@@ -48,6 +48,7 @@ class EmailServiceTest {
 
     @Test
     fun testActivationCodeGeneration() {
+
         /**
          * in this implementation an activation code has an expected length of 10
          * plus it must be made of letters and numbers only. generate and check 20
@@ -59,10 +60,12 @@ class EmailServiceTest {
                     .matches(emailService.generateActivationCode())
             )
         }
+
     }
 
     @Test
     fun testGenerateMail() {
+
         val date = Date()
         val simpleDate = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").format(date)
         val username = "user1"
@@ -79,10 +82,12 @@ class EmailServiceTest {
         Assertions.assertEquals("group03NML@gmail.com", message.from)
         Assertions.assertEquals(email, message.to?.get(0))
         Assertions.assertEquals(text, message.text)
+
     }
 
     @Test
     fun testInsertActivation() {
+
         val username = "user1"
         val psw = "P4ssw0rd!"
         val email = "user1@maildomain.invalid"
@@ -108,6 +113,7 @@ class EmailServiceTest {
             savedActivationDTO?.let { ActivationDTO(it.provisionalId, email, it.activationCode) }
         Assertions.assertEquals(activationDTO, savedActivationDTO)
         Assertions.assertEquals(sentMailNo + 1, emailServiceStub.getSentMailsSize())
+
         /**
          * while we are at it let's also test that it's the message we expect
          * being sent to the correct address. the overall formatting of the
@@ -116,6 +122,7 @@ class EmailServiceTest {
         val message = emailServiceStub.getSentMails()[0]
         Assertions.assertEquals("Activation code", message.subject)
         Assertions.assertEquals(email, message.to?.get(0))
+
     }
 
 }

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
@@ -61,14 +61,18 @@ class EmailServiceTest {
             "act1vat1on",
             date
         )
-        val text = "Hello user1! This is your activation code:\n\nact1vat1on \n\nPlease use it before ${simpleDate}.\nHave a nice day!"
+        val text =
+            "Hello user1! This is your activation code:\n\nact1vat1on \n\nPlease use it before ${simpleDate}.\nHave a nice day!"
         /**
          * "subject" and "from" field are hardcoded, while "text" is generated following the above syntax
          * and the "to" field is passed as parameter.
          */
         Assertions.assertEquals("Activation code", message.subject)
         Assertions.assertEquals("group03NML@gmail.com", message.from)
-        Assertions.assertEquals("destination@mail_provider.invalid", message.to?.get(0) ?: "FAIL - no destination specified.")
+        Assertions.assertEquals(
+            "destination@mail_provider.invalid",
+            message.to?.get(0) ?: "FAIL - no destination specified."
+        )
         Assertions.assertEquals(text, message.text)
     }
 

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
@@ -1,6 +1,10 @@
 package it.polito.wa2.group03userregistration.service
 
+import it.polito.wa2.group03userregistration.dtos.ActivationDTO
+import it.polito.wa2.group03userregistration.entities.User
+import it.polito.wa2.group03userregistration.repositories.UserRepository
 import it.polito.wa2.group03userregistration.services.EmailService
+import it.polito.wa2.group03userregistration.services.EmailServiceStub
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,6 +40,12 @@ class EmailServiceTest {
     @Autowired
     lateinit var emailService: EmailService
 
+    @Autowired
+    lateinit var emailServiceStub: EmailServiceStub
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
     @Test
     fun testActivationCodeGeneration() {
         /**
@@ -55,12 +65,10 @@ class EmailServiceTest {
     fun testGenerateMail() {
         val date = Date()
         val simpleDate = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").format(date)
-        val message = emailService.generateMail(
-            "destination@mail_provider.invalid",
-            "user1",
-            "act1vat1on",
-            date
-        )
+        val username = "user1"
+        val email = "user1@maildomain.invalid"
+        val code = "act1vat1on"
+        val message = emailService.generateMail(email, username, code, date)
         val text =
             "Hello user1! This is your activation code:\n\nact1vat1on \n\nPlease use it before ${simpleDate}.\nHave a nice day!"
         /**
@@ -69,11 +77,45 @@ class EmailServiceTest {
          */
         Assertions.assertEquals("Activation code", message.subject)
         Assertions.assertEquals("group03NML@gmail.com", message.from)
-        Assertions.assertEquals(
-            "destination@mail_provider.invalid",
-            message.to?.get(0) ?: "FAIL - no destination specified."
-        )
+        Assertions.assertEquals(email, message.to?.get(0))
         Assertions.assertEquals(text, message.text)
+    }
+
+    @Test
+    fun testInsertActivation() {
+        val username = "user1"
+        val psw = "P4ssw0rd!"
+        val email = "user1@maildomain.invalid"
+        val user = User(username, psw, email)
+        val sentMailNo = emailServiceStub.getSentMailsSize()
+
+        /**
+         * since we actually need an existing user to avoid hibernate
+         * errors, this is more of an integration test. using the repository
+         * instead of UserService is an attempt to decouple as much as
+         * possible the test from the implementation.
+         */
+        val savedUser = userRepository.save(user)
+
+        /**
+         * the stub inherits the insertActivation() method from the actual
+         * service, so it's fine to test it this way. the only change is that
+         * the email is not actually sent, but it is instead added to a list
+         * in memory that we can use to check the sending phase was triggered.
+         */
+        val savedActivationDTO = emailServiceStub.insertActivation(savedUser)
+        val activationDTO =
+            savedActivationDTO?.let { ActivationDTO(it.provisionalId, email, it.activationCode) }
+        Assertions.assertEquals(activationDTO, savedActivationDTO)
+        Assertions.assertEquals(sentMailNo + 1, emailServiceStub.getSentMailsSize())
+        /**
+         * while we are at it let's also test that it's the message we expect
+         * being sent to the correct address. the overall formatting of the
+         * message is already tested elsewhere.
+         */
+        val message = emailServiceStub.getSentMails()[0]
+        Assertions.assertEquals("Activation code", message.subject)
+        Assertions.assertEquals(email, message.to?.get(0))
     }
 
 }

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/EmailServiceTest.kt
@@ -11,6 +11,8 @@ import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import java.text.SimpleDateFormat
+import java.util.*
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -47,6 +49,27 @@ class EmailServiceTest {
                     .matches(emailService.generateActivationCode())
             )
         }
+    }
+
+    @Test
+    fun testGenerateMail() {
+        val date = Date()
+        val simpleDate = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").format(date)
+        val message = emailService.generateMail(
+            "destination@mail_provider.invalid",
+            "user1",
+            "act1vat1on",
+            date
+        )
+        val text = "Hello user1! This is your activation code:\n\nact1vat1on \n\nPlease use it before ${simpleDate}.\nHave a nice day!"
+        /**
+         * "subject" and "from" field are hardcoded, while "text" is generated following the above syntax
+         * and the "to" field is passed as parameter.
+         */
+        Assertions.assertEquals("Activation code", message.subject)
+        Assertions.assertEquals("group03NML@gmail.com", message.from)
+        Assertions.assertEquals("destination@mail_provider.invalid", message.to?.get(0) ?: "FAIL - no destination specified.")
+        Assertions.assertEquals(text, message.text)
     }
 
 }

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
@@ -51,8 +51,6 @@ class UserServiceTest {
     @Test
     fun testIsValidUser() {
 
-        // TODO("Update once service checks uniqueness in the system")
-
         val username = "user1"
         val psw = "P4ssw0rd!"
         val email = "user1@maildomain.invalid"
@@ -77,14 +75,21 @@ class UserServiceTest {
         Assertions.assertEquals(UserValidationStatus.NO_PASSWORD, userService.isValidUser(blankPassword))
         Assertions.assertEquals(UserValidationStatus.WEAK_PASSWORD, userService.isValidUser(weakPassword))
 
+        /** user with an existing email and then user with an existing username */
+        userRepository.save(validUser)
+        val duplicateUsername = User(username, psw, "anotherone@maildomain.invalid")
+        val duplicateEmail = User("another_username", psw, email)
+        Assertions.assertEquals(UserValidationStatus.USERNAME_ALREADY_EXISTS, userService.isValidUser(duplicateUsername))
+        Assertions.assertEquals(UserValidationStatus.EMAIL_ALREADY_EXISTS, userService.isValidUser(duplicateEmail))
+
     }
 
     @Test
     fun testValidateUser() {
 
-        val username = "user1"
+        val username = "user2"
         val psw = "P4ssw0rd!"
-        val email = "user1@maildomain.invalid"
+        val email = "user2@maildomain.invalid"
         val user = User(username, psw, email)
         val wrongCode = "code1"
         val randomUUID = UUID.randomUUID()
@@ -130,9 +135,9 @@ class UserServiceTest {
     @Test
     fun testRegisterUser() {
 
-        val username = "user1"
+        val username = "user3"
         val psw = "P4ssw0rd!"
-        val email = "user1@maildomain.invalid"
+        val email = "user3@maildomain.invalid"
 
         /**
          * we only test the successful case and one generic fail as all the

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
@@ -1,6 +1,7 @@
 package it.polito.wa2.group03userregistration.service
 
 import it.polito.wa2.group03userregistration.dtos.UserDTO
+import it.polito.wa2.group03userregistration.entities.User
 import it.polito.wa2.group03userregistration.enums.UserValidationStatus
 import it.polito.wa2.group03userregistration.services.UserService
 import org.junit.Ignore
@@ -36,6 +37,35 @@ class UserServiceTest {
 
     @Autowired
     lateinit var userService: UserService
+
+    @Test
+    fun testIsValidUser() {
+
+        val username = "user1"
+        val psw = "P4ssw0rd!"
+        val email = "user1@maildomain.invalid"
+
+        /** a valid user */
+        val validUser = User(username, psw, email)
+        Assertions.assertEquals(UserValidationStatus.VALID, userService.isValidUser(validUser))
+
+        /** user with blank username */
+        val blankUsername = User("", psw, email)
+        Assertions.assertEquals(UserValidationStatus.NO_USERNAME, userService.isValidUser(blankUsername))
+
+        /** user with blank email and broken email */
+        val blankEmail = User(username, psw, "")
+        val wrongEmail = User(username, psw, "wrong-looking-email")
+        Assertions.assertEquals(UserValidationStatus.NO_EMAIL, userService.isValidUser(blankEmail))
+        Assertions.assertEquals(UserValidationStatus.INVALID_EMAIL, userService.isValidUser(wrongEmail))
+
+        /** user with blank password and weak password */
+        val blankPassword = User(username, "", email)
+        val weakPassword = User(username, "ab12", email)
+        Assertions.assertEquals(UserValidationStatus.NO_PASSWORD, userService.isValidUser(blankPassword))
+        Assertions.assertEquals(UserValidationStatus.WEAK_PASSWORD, userService.isValidUser(weakPassword))
+
+    }
 
     @Ignore
     @Test

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
@@ -41,6 +41,8 @@ class UserServiceTest {
     @Test
     fun testIsValidUser() {
 
+        // TODO("Update once service checks uniqueness in the system")
+
         val username = "user1"
         val psw = "P4ssw0rd!"
         val email = "user1@maildomain.invalid"

--- a/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
+++ b/src/test/kotlin/it/polito/wa2/group03userregistration/service/UserServiceTest.kt
@@ -79,7 +79,10 @@ class UserServiceTest {
         userRepository.save(validUser)
         val duplicateUsername = User(username, psw, "anotherone@maildomain.invalid")
         val duplicateEmail = User("another_username", psw, email)
-        Assertions.assertEquals(UserValidationStatus.USERNAME_ALREADY_EXISTS, userService.isValidUser(duplicateUsername))
+        Assertions.assertEquals(
+            UserValidationStatus.USERNAME_ALREADY_EXISTS,
+            userService.isValidUser(duplicateUsername)
+        )
         Assertions.assertEquals(UserValidationStatus.EMAIL_ALREADY_EXISTS, userService.isValidUser(duplicateEmail))
 
     }


### PR DESCRIPTION
- [x] refactor email service to decouple message generation and message sending: this will help with testing.
  - ~~we could also consider removing the `sendMail` function completely, although it might facilitate stubbing the service by simply overriding that function.~~
- [x] add unit tests for email service methods.
  - closes #11.
  - ~~I'm still unsure  if `insertActivation` and `sendMail` should be tested outside the integration tests as both include the email sending phase. thoughts? should do these more complex tests here as well since it's not hard?~~
- [x] implement mock email service to use it #12.
- [x] add unit tests for user service methods.
  - closes #12, **wip**.
  - #19 + tests

open points - check the boxes if you think we can skip them in this PR:
- [x] the EmailService does not have redundant checks and expects to get properly formatted fields (eg. user email): it's reasonable but probably not best practice.
- [x] as Activation objects have auto-generated timestamps, testing an expired activation code would require an extra stub for the Activation class, so I skipped it.
- [ ] #17 
- [ ] #18 